### PR TITLE
Get dungeon barren/woth info

### DIFF
--- a/code/patch.py
+++ b/code/patch.py
@@ -11,7 +11,8 @@ sectionsInfo = [line.split()[1:6] for line in lines if line.split() and line.spl
 sections = ((sec[0], int(sec[2],16), int(sec[4],16), int(sec[1],16)) for sec in sectionsInfo if int(sec[2],16) != 0)
 
 # Put here the symbols from the patch which are needed by the app
-desiredSymbols = ("rItemOverrides", "gSettingsContext", "gSpoilerData", "rScrubRandomItemPrices", "rDungeonRewardOverrides", "rCustomMessages", "numCustomMessageEntries", "ptrCustomMessageEntries", "rShopsanityPrices", "rEntranceOverrides", "rBGMOverrides", "rSfxData")
+desiredSymbols = ("rItemOverrides", "gSettingsContext", "gSpoilerData", "rScrubRandomItemPrices", "rDungeonRewardOverrides", "rCustomMessages", 
+"numCustomMessageEntries", "ptrCustomMessageEntries", "rShopsanityPrices", "rEntranceOverrides", "rBGMOverrides", "rSfxData", "rDungeonInfoData")
 
 nmResult = subprocess.run([os.environ["DEVKITARM"] + r'/bin/arm-none-eabi-nm', elf], stdout=subprocess.PIPE)
 nmLines = str(nmResult.stdout).split('\\n')

--- a/code/src/gfx.c
+++ b/code/src/gfx.c
@@ -24,6 +24,8 @@ static u64 lastTick = 0;
 static u64 ticksElapsed = 0;
 static bool isAsleep = false;
 
+DungeonInfo rDungeonInfoData[10]; 
+
 #define TICKS_PER_SEC 268123480
 #define MAX_TICK_DELTA (TICKS_PER_SEC * 3)
 

--- a/code/src/settings.h
+++ b/code/src/settings.h
@@ -295,6 +295,12 @@ typedef enum {
   SHUFFLESFX_CHAOS,
 } ShuffleSFXSetting;
 
+typedef enum {
+  DUNGEON_NEITHER,
+  DUNGEON_BARREN,
+  DUNGEON_WOTH,
+} DungeonInfo;
+
 typedef struct {
   u8 hashIndexes[5];
 

--- a/source/hints.cpp
+++ b/source/hints.cpp
@@ -108,6 +108,8 @@ constexpr std::array<HintSetting, 4> hintSettingTable{{
   },
 }};
 
+std::array<DungeonInfo, 10> dungeonInfoData;
+
 static Area* GetHintRegion(const AreaKey area) {
 
   std::vector<AreaKey> alreadyChecked = {};
@@ -691,6 +693,52 @@ void CreateAllHints() {
 
   //get barren regions
   auto barrenLocations = CalculateBarrenRegions();
+
+  //Calculate dungeon woth/barren info
+
+  std::vector<std::string> dungeonNames = {"Deku Tree", "Dodongos Cavern", "Jabu Jabus Belly", "Forest Temple", "Fire Temple",
+                                           "Water Temple", "Spirit Temple", "Shadow Temple", "Bottom of the Well", "Ice Cavern"};
+  //Get list of all barren dungeons
+  std::vector<std::string> barrenDungeons;
+  for (LocationKey barrenLocation : barrenLocations) {
+    std::string barrenRegion = GetHintRegion(Location(barrenLocation)->GetParentRegionKey())->scene;
+    bool isDungeon = std::find(dungeonNames.begin(), dungeonNames.end(), barrenRegion) != dungeonNames.end();
+    //If it hasn't already been added to the list and is a dungeon, add to list
+    if (isDungeon && std::find(barrenDungeons.begin(), barrenDungeons.end(), barrenRegion) == barrenDungeons.end()) {
+      barrenDungeons.push_back(barrenRegion);
+    }
+  }
+  PlacementLog_Msg("\nBarren Dungeons:\n");
+  for (std::string barrenDungeon : barrenDungeons) {
+    PlacementLog_Msg(barrenDungeon + "\n");
+  }
+
+  //Get list of all woth dungeons
+  std::vector<std::string> wothDungeons;
+  for (LocationKey wothLocation : wothLocations) {
+    std::string wothRegion = GetHintRegion(Location(wothLocation)->GetParentRegionKey())->scene;
+    bool isDungeon = std::find(dungeonNames.begin(), dungeonNames.end(), wothRegion) != dungeonNames.end();
+    //If it hasn't already been added to the list and is a dungeon, add to list
+    if (isDungeon && std::find(wothDungeons.begin(), wothDungeons.end(), wothRegion) == wothDungeons.end()) {
+      wothDungeons.push_back(wothRegion);
+    }
+  }
+  PlacementLog_Msg("\nWoth Dungeons:\n");
+  for (std::string wothDungeon : wothDungeons) {
+    PlacementLog_Msg(wothDungeon + "\n");
+  }
+
+  //Set DungeonInfo array for each dungeon
+  for (uint i = 0; i < dungeonInfoData.size(); i++) {
+    std::string dungeonName = dungeonNames[i];
+    if (std::find(barrenDungeons.begin(), barrenDungeons.end(), dungeonName) != barrenDungeons.end()) {
+      dungeonInfoData[i] = DungeonInfo::DUNGEON_BARREN;
+    } else if (std::find(wothDungeons.begin(), wothDungeons.end(), dungeonName) != wothDungeons.end()) {
+      dungeonInfoData[i] = DungeonInfo::DUNGEON_WOTH;
+    } else {
+      dungeonInfoData[i] = DungeonInfo::DUNGEON_NEITHER;
+    }
+  }
 
   //while there are still gossip stones remaining
   while (FilterFromPool(gossipStoneLocations, [](const LocationKey loc){return Location(loc)->GetPlacedItemKey() == NONE;}).size() != 0) {

--- a/source/hints.hpp
+++ b/source/hints.hpp
@@ -8,6 +8,7 @@
 #include "text.hpp"
 #include "random.hpp"
 #include "settings.hpp"
+#include "../code/src/settings.h"
 
 enum class HintType {
   Trial,
@@ -185,6 +186,9 @@ private:
     Text clearText;
     HintCategory type;
 };
+
+//10 dungeons as GTG and GC are excluded
+extern std::array<DungeonInfo, 10> dungeonInfoData;
 
 extern void CreateAllHints();
 extern void CreateMerchantsHints();

--- a/source/patch.cpp
+++ b/source/patch.cpp
@@ -7,6 +7,7 @@
 #include "shops.hpp"
 #include "spoiler_log.hpp"
 #include "entrance.hpp"
+#include "hints.hpp"
 
 #include <array>
 #include <cstring>
@@ -340,6 +341,16 @@ bool WriteAllPatches() {
   patchOffset = V_TO_P(RSFXDATA_ADDR);
   patchSize = sizeof(SFXData);
   if (!WritePatch(patchOffset, patchSize, (char*)(&SFX::GetSFXData()), code, bytesWritten, totalRW, buf)) {
+    return false;
+  }
+
+  /*---------------------------------
+  |        rDungeonInfoData         |
+  ---------------------------------*/
+
+  patchOffset = V_TO_P(RDUNGEONINFODATA_ADDR);
+  patchSize = sizeof(dungeonInfoData);
+  if (!WritePatch(patchOffset, patchSize, (char*)(&dungeonInfoData), code, bytesWritten, totalRW, buf)) {
     return false;
   }
 


### PR DESCRIPTION
Adds an array to gfx.c containing info for the first 10 dungeons (in the same order as they print on the dungeon info screen) since those are the dungeons with maps/compasses. In this array is an enum that will tell you for each of these 10 dungeons if they're barren, woth, or neither.